### PR TITLE
Cached version of mathRandomGenerator

### DIFF
--- a/math.go
+++ b/math.go
@@ -6,6 +6,7 @@ package randutil
 
 import (
 	mrand "math/rand" // used for non-crypto unique ID and random port selection
+	"strings"
 	"sync"
 	"time"
 )
@@ -67,10 +68,11 @@ func (g *mathRandomGenerator) Uint64() uint64 {
 }
 
 func (g *mathRandomGenerator) GenerateString(n int, runes string) string {
-	letters := []rune(runes)
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[g.Intn(len(letters))]
+	letters := []byte(runes)
+	var b strings.Builder
+	b.Grow(n)
+	for i := 0; i < n; i++ {
+		b.WriteByte(letters[g.Intn(len(letters))])
 	}
-	return string(b)
+	return b.String()
 }

--- a/rand_test.go
+++ b/rand_test.go
@@ -71,3 +71,44 @@ func TestRandomGeneratorCollision(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkRandomGeneratorGenerateString(t *testing.B) {
+	g := NewMathRandomGenerator()
+
+	testCases := map[string]struct {
+		gen func(t *testing.B) string
+	}{
+		"MathRandom": {
+			gen: func(t *testing.B) string {
+				return g.GenerateString(10, runesAlpha)
+			},
+		},
+	}
+
+	const N = 100
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.B) {
+			for iter := 0; iter < t.N; iter++ {
+				var wg sync.WaitGroup
+				var mu sync.Mutex
+
+				rands := make([]string, 0, N)
+
+				for i := 0; i < N; i++ {
+					wg.Add(1)
+					go func() {
+						r := testCase.gen(t)
+						mu.Lock()
+						rands = append(rands, r)
+						mu.Unlock()
+						wg.Done()
+					}()
+				}
+				wg.Wait()
+			}
+			t.ReportAllocs()
+		})
+	}
+}


### PR DESCRIPTION
I observed that we create a new `mathRandomGenerator` in `NewCandidatePeerReflexive`. 

And it allocates a lot of memory. Attaching the alloc profile.

<img width="715" alt="Screenshot 2023-06-02 at 1 35 36 PM" src="https://github.com/pion/randutil/assets/7821757/84dd9cca-0198-424f-a222-6ca2076f2a3d">

But, it seems like we don't call `GenerateString` for most of the cases. Now this gives us opportunity to lazily initialize some things, which i have tried in this PR.

Here are the results:
<img width="1070" alt="Screenshot 2023-06-02 at 1 33 29 PM" src="https://github.com/pion/randutil/assets/7821757/900f1128-5152-496b-9f2e-5fc4662d1688">
<img width="1121" alt="Screenshot 2023-06-02 at 1 33 46 PM" src="https://github.com/pion/randutil/assets/7821757/5237db8f-56e3-43b1-bd05-8665d463271a">
