### PR TITLE
Update lint rules, use testify/assert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
-      - ^print(ln)?$
+      - ^print(ln)?$      
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
         - forbidigo
+        - gocognit
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -6,6 +6,8 @@ package randutil
 import (
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCryptoRandomGenerator(t *testing.T) {
@@ -13,15 +15,9 @@ func TestCryptoRandomGenerator(t *testing.T) {
 
 	for i := 0; i < 10000; i++ {
 		s, err := GenerateCryptoRandomString(10, runesAlpha)
-		if err != nil {
-			t.Error(err)
-		}
-		if len(s) != 10 {
-			t.Error("Generator returned invalid length")
-		}
-		if !isLetter(s) {
-			t.Errorf("Generator returned unexpected character: %s", s)
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, 10, len(s), "Generated string was not the correct length")
+		assert.True(t, isLetter(s), "Generator returned unexpected character: %s", s)
 	}
 }
 
@@ -30,9 +26,8 @@ func TestCryptoUint64(t *testing.T) {
 	localMax := uint64(0)
 	for i := 0; i < 10000; i++ {
 		r, err := CryptoUint64()
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
+
 		if r < localMin {
 			localMin = r
 		}
@@ -40,10 +35,7 @@ func TestCryptoUint64(t *testing.T) {
 			localMax = r
 		}
 	}
-	if localMin > 0x1000000000000000 {
-		t.Error("Value around lower boundary was not generated")
-	}
-	if localMax < 0xF000000000000000 {
-		t.Error("Value around upper boundary was not generated")
-	}
+
+	assert.Greater(t, uint64(0x1000000000000000), localMin, "Value around lower boundary was not generated")
+	assert.Less(t, uint64(0xF000000000000000), localMax, "Value around upper boundary was not generated")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/pion/randutil
 
 go 1.20
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/math_test.go
+++ b/math_test.go
@@ -6,6 +6,8 @@ package randutil
 import (
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMathRandomGenerator(t *testing.T) {
@@ -14,12 +16,8 @@ func TestMathRandomGenerator(t *testing.T) {
 
 	for i := 0; i < 10000; i++ {
 		s := g.GenerateString(10, runesAlpha)
-		if len(s) != 10 {
-			t.Error("Generator returned invalid length")
-		}
-		if !isLetter(s) {
-			t.Errorf("Generator returned unexpected character: %s", s)
-		}
+		assert.Equal(t, 10, len(s), "Generated string was not the correct length")
+		assert.True(t, isLetter(s), "Generator returned unexpected character: %s", s)
 	}
 }
 
@@ -30,9 +28,9 @@ func TestIntn(t *testing.T) {
 	localMax := 0
 	for i := 0; i < 10000; i++ {
 		r := g.Intn(100)
-		if r < 0 || r >= 100 {
-			t.Fatalf("Out of range of Intn(100): %d", r)
-		}
+		assert.GreaterOrEqual(t, r, 0, "Generated value was not greater than 0")
+		assert.Less(t, r, 100, "Generated value was not less than 100")
+
 		if r < localMin {
 			localMin = r
 		}
@@ -40,12 +38,8 @@ func TestIntn(t *testing.T) {
 			localMax = r
 		}
 	}
-	if localMin > 10 {
-		t.Error("Value around lower boundary was not generated")
-	}
-	if localMax < 90 {
-		t.Error("Value around upper boundary was not generated")
-	}
+	assert.Greater(t, 10, localMin, "Value around lower boundary was not generated")
+	assert.Less(t, 90, localMax, "Value around upper boundary was not generated")
 }
 
 func TestUint64(t *testing.T) {
@@ -62,12 +56,8 @@ func TestUint64(t *testing.T) {
 			localMax = r
 		}
 	}
-	if localMin > 0x1000000000000000 {
-		t.Error("Value around lower boundary was not generated")
-	}
-	if localMax < 0xF000000000000000 {
-		t.Error("Value around upper boundary was not generated")
-	}
+	assert.Greater(t, uint64(0x1000000000000000), localMin, "Value around lower boundary was not generated")
+	assert.Less(t, uint64(0xF000000000000000), localMax, "Value around upper boundary was not generated")
 }
 
 func TestUint32(t *testing.T) {
@@ -84,10 +74,6 @@ func TestUint32(t *testing.T) {
 			localMax = r
 		}
 	}
-	if localMin > 0x10000000 {
-		t.Error("Value around lower boundary was not generated")
-	}
-	if localMax < 0xF0000000 {
-		t.Error("Value around upper boundary was not generated")
-	}
+	assert.Greater(t, uint32(0x10000000), localMin, "Value around lower boundary was not generated")
+	assert.Less(t, uint32(0xF0000000), localMax, "Value around upper boundary was not generated")
 }

--- a/rand_test.go
+++ b/rand_test.go
@@ -6,6 +6,8 @@ package randutil
 import (
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const runesAlpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -26,9 +28,7 @@ func TestRandomGeneratorCollision(t *testing.T) {
 				t.Helper()
 
 				s, err := GenerateCryptoRandomString(10, runesAlpha)
-				if err != nil {
-					t.Fatal(err)
-				}
+				assert.NoError(t, err)
 
 				return s
 			},
@@ -59,15 +59,11 @@ func TestRandomGeneratorCollision(t *testing.T) {
 				}
 				wg.Wait()
 
-				if len(rands) != maxIterations {
-					t.Fatal("Failed to generate randoms")
-				}
+				assert.Equal(t, maxIterations, len(rands), "Failed to generate all randoms")
 
 				for i := 0; i < maxIterations; i++ {
 					for j := i + 1; j < maxIterations; j++ {
-						if rands[i] == rands[j] {
-							t.Fatalf("generateRandString caused collision: %s == %s", rands[i], rands[j])
-						}
+						assert.NotEqual(t, rands[i], rands[j], "generateRandString caused collision")
 					}
 				}
 			}


### PR DESCRIPTION
#### Description

Update lint rules to forbid the use of direct testing.T helpers.

https://github.com/pion/.goassets/pull/222

#### Reference issue

N/A
